### PR TITLE
Hyperlink DOIs against preferred resolver

### DIFF
--- a/docs/doiLinks.hs
+++ b/docs/doiLinks.hs
@@ -4,6 +4,6 @@ main = toJsonFilter doiLinks
 
 doiLinks :: Inline -> Inline
 doiLinks (Str s)
-  | (take 4 s) == "doi:" = RawInline "html" ("doi:<a href=\"http://dx.doi.org/" ++ (drop 4 s) ++ "\">" ++ (drop 4 s) ++ "</a>")
+  | (take 4 s) == "doi:" = RawInline "html" ("doi:<a href=\"https://doi.org/" ++ (drop 4 s) ++ "\">" ++ (drop 4 s) ++ "</a>")
   | otherwise  = Str s
 doiLinks x      = x


### PR DESCRIPTION
Hello :-)

The DOI foundation recommends [this new resolver](https://www.doi.org/doi_handbook/3_Resolution.html#3.8). Yes, a bit ironic that they would change the URL of their service, but it's now [encrypted](https://www.ssllabs.com/ssltest/analyze.html?d=doi.org) and the old links with the `dx` subdomain continue to work.

Although there is no urgent need to do anything, I'd hereby like to suggest to follow the new recommendation and the code that hyperlinks DOIs.

Cheers!